### PR TITLE
feat: use the github aws oidc module

### DIFF
--- a/modules/gateway.tf
+++ b/modules/gateway.tf
@@ -247,3 +247,8 @@ resource "aws_cloudwatch_log_group" "gateway_api_access" {
   name              = "API-Gateway-Access-Logs_${aws_api_gateway_rest_api.gateway_api.id}/${local.stage_name}"
   retention_in_days = var.cloudwatch_log_retention
 }
+
+output "api_execute_admin_policy_arn" {
+  value       = aws_iam_policy.api_execute_admin.arn
+  description = "ARN of the API execute admin policy"
+}

--- a/modules/github_aws_oidc_setup.tf
+++ b/modules/github_aws_oidc_setup.tf
@@ -1,0 +1,19 @@
+variable "repositories" {
+  description = "List of GitHub repositories to set up AWS OIDC"
+  type        = list(string)
+  default     = ["terraform-github-aws-oidc"]
+}
+
+module "github_aws_oidc" {
+  source  = "git@github.com:observeinc/terraform-github-aws-oidc.git?ref=1.1.2"
+  for_each = toset(var.repositories)
+
+  organization = "observeinc" 
+  repository   = each.value
+  policy_arn   = module.gateway.api_execute_admin_policy_arn
+}
+
+output "aws_oidc_role_arns" {
+  value = { for repo in var.repositories : repo => module.github_aws_oidc[repo].role_arn }
+  description = "The ARNs of the AWS IAM roles created for each GitHub repository"
+}


### PR DESCRIPTION
## Proposed changes

This pull request introduces changes to integrate GitHub OIDC with AWS via Terraform. It enables automated role creation for GitHub Actions to securely interact with AWS resources without using static credentials. The PR includes updates to our Terraform configurations to use the `terraform-github-aws-oidc` module, ensuring secure and efficient CI/CD workflows.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (changes to code, which do not change application behavior)

## Relevant Links

- Terraform Module Repository: [terraform-github-aws-oidc](https://github.com/observeinc/terraform-github-aws-oidc)
- Terraform Cloud Setup Guide: [Setting Up Terraform Cloud](https://www.terraform.io/cloud-docs)

## Further comments

This implementation requires the setup of a `GITHUB_TOKEN` with sufficient permissions to read and create repository secrets. This is essential for the module to manage AWS OIDC roles and GitHub Actions secrets securely.

### Setting Up `GITHUB_TOKEN`

1. **Create a Personal Access Token (PAT) in GitHub**: Ensure it has the `repo`, `admin:repo_hook`, and `admin:org` scopes.
2. **Add the Token to Terraform Cloud**:
   - In the Terraform Cloud workspace, under "Variables," add the token as an environment variable (`GITHUB_TOKEN`).
   - Mark it as "Sensitive" to keep it secure.
3. **Update Terraform Configurations**: Ensure the configurations reference the `github_token` variable correctly and it's marked as sensitive.
